### PR TITLE
Update README.md: missing `let assert`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pub fn main() {
 
   // Run the query against the PostgreSQL database
   // The int `1` is given as a parameter
-  assert Ok(response) = 
+  let assert Ok(response) = 
     pgo.execute(sql, db, [pgo.int(1)], return_type)
 
   // And then do something with the returned results


### PR DESCRIPTION
still using old assert syntax