### PR TITLE
Timestamp handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Provided functions for handling timestamp values. The `timestamp` function
+  coerces a `#(#(Int, Int, Int), #(Int, Int, Int))` value representing
+  `#(#(year, month, day), #(hour, minute, second))` into a `Value`. The
+  `decode_timestamp` function can be used to decode a dynamic value returned from
+  the database as a timestamp in the same nested tuple format.
+
+
 ## v0.8.0 - 2024-05-20
 
 - Added `array` column handling, accepting a `List` as value.

--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -495,3 +495,13 @@ pub fn error_code_name(error_code: String) -> Result(String, Nil) {
     _ -> Error(Nil)
   }
 }
+
+/// Checks to see if the value is formatted as `#(#(Int, Int, Int), #(Int, Int, Int))`
+/// to represent `#(#(year, month, day), #(hour, minute, second))`, and returns the
+/// value if it is.
+pub fn decode_timestamp(value: dynamic.Dynamic) {
+  dynamic.tuple2(
+    dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int),
+    dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int),
+  )(value)
+}

--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -158,6 +158,7 @@ pub fn text(a: String) -> Value
 @external(erlang, "gleam_pgo_ffi", "coerce")
 pub fn bytea(a: BitArray) -> Value
 
+/// Coerce a timestamp represented as `#(#(year, month, day), #(hour, minute, second))` into a `Value`.
 @external(erlang, "gleam_pgo_ffi", "coerce")
 pub fn array(a: List(a)) -> Value
 

--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -161,6 +161,9 @@ pub fn bytea(a: BitArray) -> Value
 @external(erlang, "gleam_pgo_ffi", "coerce")
 pub fn array(a: List(a)) -> Value
 
+@external(erlang, "gleam_pgo_ffi", "coerce")
+pub fn timestamp(a: #(#(Int, Int, Int), #(Int, Int, Int))) -> Value
+
 pub fn nullable(inner_type: fn(a) -> Value, value: Option(a)) -> Value {
   case value {
     Some(term) -> inner_type(term)

--- a/test/gleam/pgo_test.gleam
+++ b/test/gleam/pgo_test.gleam
@@ -117,10 +117,7 @@ pub fn selecting_rows_test() {
         dynamic.string,
         dynamic.bool,
         dynamic.list(dynamic.string),
-        dynamic.tuple2(
-          dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int),
-          dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int),
-        ),
+        pgo.decode_timestamp,
       ),
     )
 
@@ -339,10 +336,7 @@ pub fn datetime_test() {
     #(#(2022, 10, 10), #(11, 30, 30)),
     "timestamp",
     pgo.timestamp,
-    dynamic.tuple2(
-      dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int),
-      dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int),
-    ),
+    pgo.decode_timestamp,
   )
   |> pgo.disconnect
 }

--- a/test/reset_db.sh
+++ b/test/reset_db.sh
@@ -18,7 +18,8 @@ CREATE TABLE cats (
   id SERIAL PRIMARY KEY,
   name VARCHAR(50) NOT NULL,
   is_cute boolean NOT NULL DEFAULT true,
-  colors VARCHAR(50)[] NOT NULL
+  colors VARCHAR(50)[] NOT NULL,
+  last_petted_at TIMESTAMP NOT NULL
 );
 SQL
 


### PR DESCRIPTION
*I've built this on top of the 0.7.0 tag but that isn't in main yet and so it adds to the diff*

This adds `pgo.timestamp` as a converter function from `#(#(Int, Int, Int), #(Int, Int, Int))` to a `pgo.Value`. This provides some indication of how to handle timestamp columns with this library. Also extends the tests to cover this. 

As noted in the commit message, I think it might be reasonable to have a `pgo/dynamic.timestamp` module/function to decode the tuple structure that pgo uses to make that side easier too. Happy to add that if it seems relevant.

Not sure if any of this is appropriate. Happy to be told if it isn't. It is based off my attempts to explore this area and better understand how one is meant to handle timestamps with this library. I think similar work could go into timestamps with time zones too but I realise there might be issues with the underlying pgo library there. Not sure.