### PR TITLE
Add support for SSL options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.13.0 - 2024-07-09
+
+- Fix the SSL options with correct default when SSL is enabled.
+
 ## v0.12.0 - 2024-07-03
 
 - Added the `transaction` function and `TransactionError` type.


### PR DESCRIPTION
That PR add support for SSL options.
This is required [since OTP 26](https://www.erlang.org/blog/otp-26-highlights/#ssl-safer-defaults).

PR to merge after arrays has been merged. #22