### PR TITLE
fix:uri_config not supporting "postgresql" scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.0 - 2024-05-31
+
+- Fixed the issue where `uri_config` could parse connections string starting with `postgres://`, but not `postgresql://`.
+
 ## v0.9.0 - 2024-05-20
 
 - Provided functions for handling timestamp values. The `timestamp` function

--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -86,13 +86,16 @@ pub fn url_config(database_url: String) -> Result(Config, Nil) {
   use uri <- result.then(uri.parse(database_url))
   use #(userinfo, host, path, db_port) <- result.then(case uri {
     Uri(
-      scheme: Some("postgres"),
+      scheme: Some(scheme),
       userinfo: Some(userinfo),
       host: Some(host),
       port: Some(db_port),
       path: path,
       ..,
-    ) -> Ok(#(userinfo, host, path, db_port))
+    ) -> {
+      let assert True = list.contains(["postgres", "postgresql"], scheme)
+      Ok(#(userinfo, host, path, db_port))
+    }
     _ -> Error(Nil)
   })
   use #(user, password) <- result.then(case string.split(userinfo, ":") {

--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -93,8 +93,10 @@ pub fn url_config(database_url: String) -> Result(Config, Nil) {
       path: path,
       ..,
     ) -> {
-      let assert True = list.contains(["postgres", "postgresql"], scheme)
-      Ok(#(userinfo, host, path, db_port))
+      case list.contains(["postgres", "postgresql"], scheme) {
+        True -> Ok(#(userinfo, host, path, db_port))
+        False -> Error(Nil)
+      }
     }
     _ -> Error(Nil)
   })

--- a/test/gleam/pgo_test.gleam
+++ b/test/gleam/pgo_test.gleam
@@ -18,6 +18,20 @@ pub fn url_config_everything_test() {
   ))
 }
 
+pub fn url_config_alternative_postgres_protocol_test() {
+  pgo.url_config("postgresql://u:p@db.test:1234/my_db")
+  |> should.equal(Ok(
+    pgo.Config(
+      ..pgo.default_config(),
+      host: "db.test",
+      port: 1234,
+      database: "my_db",
+      user: "u",
+      password: Some("p"),
+    ),
+  ))
+}
+
 pub fn url_config_not_postgres_protocol_test() {
   pgo.url_config("foo://u:p@db.test:1234/my_db")
   |> should.equal(Error(Nil))


### PR DESCRIPTION
`pgo.uri_config` was only supporting `postgres` scheme, but `postgresql` is considred valid by the PG docs too.
Related issue: https://github.com/lpil/pgo/issues/24
Not sure if this is the best solution, tho. Ready to change code if you want :) 👍🏻 