### PR TITLE
Put timestamp function doc on the right function

### DIFF
--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -163,10 +163,10 @@ pub fn text(a: String) -> Value
 @external(erlang, "gleam_pgo_ffi", "coerce")
 pub fn bytea(a: BitArray) -> Value
 
-/// Coerce a timestamp represented as `#(#(year, month, day), #(hour, minute, second))` into a `Value`.
 @external(erlang, "gleam_pgo_ffi", "coerce")
 pub fn array(a: List(a)) -> Value
 
+/// Coerce a timestamp represented as `#(#(year, month, day), #(hour, minute, second))` into a `Value`.
 @external(erlang, "gleam_pgo_ffi", "coerce")
 pub fn timestamp(a: #(#(Int, Int, Int), #(Int, Int, Int))) -> Value
 


### PR DESCRIPTION
It seems I messed this up in my PR. I'm not sure how.