### PR TITLE
Fix documentation typo.

### DIFF
--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -54,9 +54,9 @@ pub type Config {
 
 /// The internet protocol version to use.
 pub type IpVersion {
-  /// Internet Protocol version 6 (IPv6)
-  Ipv4
   /// Internet Protocol version 4 (IPv4)
+  Ipv4
+  /// Internet Protocol version 6 (IPv6)
   Ipv6
 }
 


### PR DESCRIPTION
The doc comments of IPv4 and IPv6 were swapped.