### PR TITLE
Add ability to return maps from rows after query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "25.1"
-          gleam-version: "1.1.0"
+          gleam-version: "1.4.1"
           rebar3-version: "3"
           # ImageOS: ubuntu20
       - run: gleam build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.14.0 - 2024-08-07
+
+- Add ability to return rows as maps instead of tuple.
+
 ## v0.13.0 - 2024-07-17
 
 - Host CA certs are now used to verify SSL by default.

--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -47,6 +47,9 @@ pub type Config {
     trace: Bool,
     /// Which internet protocol to use for this connection
     ip_version: IpVersion,
+    /// By default, PGO will return a n-tuple, in the order of the query.
+    /// By setting `rows_as_map` to `True`, the result will be `Dict`.
+    rows_as_map: Bool,
   )
 }
 
@@ -76,6 +79,7 @@ pub fn default_config() -> Config {
     idle_interval: 1000,
     trace: False,
     ip_version: Ipv4,
+    rows_as_map: False,
   )
 }
 

--- a/src/gleam_pgo_ffi.erl
+++ b/src/gleam_pgo_ffi.erl
@@ -53,7 +53,8 @@ connect(Config) ->
         queue_interval = QueueInterval,
         idle_interval = IdleInterval,
         trace = Trace,
-        ip_version = IpVersion
+        ip_version = IpVersion,
+        rows_as_map = RowsAsMap
     } = Config,
     SslOptions = default_ssl_options(Host, Ssl),
     Options1 = #{
@@ -69,6 +70,7 @@ connect(Config) ->
         queue_interval => QueueInterval,
         idle_interval => IdleInterval,
         trace => Trace,
+        decode_opts => [{return_rows_as_maps, RowsAsMap}],
         socket_options => case IpVersion of
             ipv4 -> [];
             ipv6 -> [inet6]
@@ -98,7 +100,7 @@ transaction(#pgo_pool{name = Name} = Conn, Callback) ->
         error:{gleam_pgo_rollback_transaction, Reason} ->
             {error, {transaction_rolled_back, Reason}}
     end.
-  
+
 
 query(#pgo_pool{name = Name}, Sql, Arguments) ->
     case pgo:query(Sql, Arguments, #{pool => Name}) of
@@ -114,8 +116,8 @@ convert_error(none_available) ->
 convert_error({pgo_protocol, {parameters, Expected, Got}}) ->
     {unexpected_argument_count, Expected, Got};
 convert_error({pgsql_error, #{
-    message := Message, 
-    constraint := Constraint, 
+    message := Message,
+    constraint := Constraint,
     detail := Detail
 }}) ->
     {constraint_violated, Message, Constraint, Detail};


### PR DESCRIPTION
Hi!

Currently, `gleam_pgo` will return all rows as tuples. To be able to reuse decoders between JSON and PGO, it would be nice to let the possibility for users to return rows directly.

An example:

```gleam
pub type Dummy {
  Dummy(
    id: String,
    dummy: Int,
    field: String,
  )
}

pub fn encode(dummy: Dummy) {
  json.object([
    #("id", json.string(dummy.id)),
    #("dummy", json.int(dummy.int)),
    #("field", json.string(dummy.field)),
  ])
  |> json.to_string
}

pub fn decode(dyn: dynamic.Dynamic) {
  decode.decode3(
    Dummy,
    dynamic.field("id", dynamic.string),
    dynamic.field("dummy, dynamic.int),
    dynamic.field("field", dynamic.string),
  )(dyn)
}

pub fn query() {
  "SELECT id, dummy, field
   FROM dummies"
  |> pgo.execute(db, [], decode)
}
```