### PR TITLE
Ensure ssl is started before running connection and querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.15.0 - Unreleased
+
+- Ensure `ssl` and `pgo` are running before using `gleam_pgo`.
+
 ## v0.14.0 - 2024-08-15
 
 - Add ability to return rows as maps instead of tuple.

--- a/gleam.toml
+++ b/gleam.toml
@@ -17,3 +17,7 @@ pgo = ">= 0.12.0 and < 2.0.0"
 [dev-dependencies]
 gleeunit = "~> 1.0"
 exception = ">= 2.0.0 and < 3.0.0"
+
+[erlang]
+# Starting an SSL connection relies on ssl application to be started.
+extra_applications = ["ssl"]


### PR DESCRIPTION
Hi!

[Follow-up of a long bugfix on Discord](https://discord.com/channels/768594524158427167/1276197632875696253) that is finally fixed.

Unless I'm in error, that PR should fix it by ensuring `ssl` is running.